### PR TITLE
OSGi Bundle for liferay 7.2, bnd.bnd added

### DIFF
--- a/jpacontainer-addon/bnd.bnd
+++ b/jpacontainer-addon/bnd.bnd
@@ -1,0 +1,4 @@
+Bundle-Name: ${project.name}
+Bundle-Version: ${project.version}
+Bundle-SymbolicName: ${project.groupId}.${project.artifactId}
+Export-Package: com.vaadin.addon.jpacontainer, com.vaadin.addon.jpacontainer.filter, com.vaadin.addon.jpacontainer.util

--- a/jpacontainer-addon/pom.xml
+++ b/jpacontainer-addon/pom.xml
@@ -178,10 +178,41 @@
             <version>0.3.0</version>
             <scope>test</scope>
         </dependency>
+	<dependency>
+			<groupId>org.osgi</groupId>
+			<artifactId>osgi.core</artifactId>
+			<version>6.0.0</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.osgi</groupId>
+			<artifactId>osgi.annotation</artifactId>
+			<version>6.0.1</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.osgi</groupId>
+			<artifactId>osgi.cmpn</artifactId>
+			<version>6.0.0</version>
+			<scope>provided</scope>
+		</dependency>
+
     </dependencies>
     <build>
         <finalName>vaadin-jpacontainer-${project.version}</finalName>
         <plugins>
+	  <plugin>
+				<groupId>biz.aQute.bnd</groupId>
+				<artifactId>bnd-maven-plugin</artifactId>
+				<version>4.2.0</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>bnd-process</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
             <plugin>
                 <groupId>com.mycila.maven-license-plugin</groupId>
                 <artifactId>maven-license-plugin</artifactId>
@@ -226,8 +257,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                     <encoding>UTF-8</encoding>
                 </configuration>
             </plugin>
@@ -241,14 +272,24 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
+		<version>3.1.2</version>
                 <configuration>
                     <archive>
+		      <manifestFile>
+							${project.build.outputDirectory}/META-INF/MANIFEST.MF
+		      </manifestFile>
+
+		      <!-- manifest>
+			<addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+		      </manifest>
                         <manifestEntries>
                             <Implementation-Version>${Implementation-Version}</Implementation-Version>
                             <Implementation-Title>${Implementation-Title}</Implementation-Title>
                             <Implementation-Vendor>${Implementation-Vendor}</Implementation-Vendor>
                             <Vaadin-Package-Version>1</Vaadin-Package-Version>
-                        </manifestEntries>
+			    <Implementation-Build>${buildNumber}</Implementation-Build>
+			    <Implementation-Branch>${scmBranch}</Implementation-Branch>
+                        </manifestEntries-->
                     </archive>
                     <!-- exclude other META-INF data under build directory ??? -->
                     <!-- <includes> -->
@@ -285,7 +326,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.9.1</version>
+                <version>3.1.1</version>
                 <executions>
                     <execution>
                         <phase>package</phase>

--- a/pom.xml
+++ b/pom.xml
@@ -142,8 +142,8 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <configuration>
-                        <source>1.6</source>
-                        <target>1.6</target>
+                        <source>1.7</source>
+                        <target>1.7</target>
                         <encoding>UTF-8</encoding>
                     </configuration>
                 </plugin>


### PR DESCRIPTION
I have added bnd.bnd file and now:
2019-07-26 14:52:33.210 INFO  [fileinstall-/opt/liferay/jufo/liferay-ce-portal-7.2.0-ga1/osgi/modules][BundleStartStopLogger:39] STARTED com.vaadin.addon.jpacontainer_4.0.1.SNAPSHOT [1101]

The result MANIFEST file is 

Manifest-Version: 1.0
Bundle-Description: "Vaadin JPAContainer"
Implementation-Title: Vaadin JPAContainer
Bundle-License: "Apache License version 2.0";link="http://www.apache.o
 rg/licenses/LICENSE-2.0.html"
Bundle-SymbolicName: com.vaadin.addon.jpacontainer
Implementation-Version: 4.0.1-SNAPSHOT
Bnd-LastModified: 1564141687886
Bundle-ManifestVersion: 2
Bundle-DocURL: http://vaadin.com/
Bundle-Vendor: Vaadin Ltd
Import-Package: com.vaadin.addon.jpacontainer.filter;version="[4.0,5)"
 ,com.vaadin.addon.jpacontainer.util,com.vaadin.event;version="[8.0,9)
 ",com.vaadin.server;version="[8.0,9)",com.vaadin.shared;version="[8.0
 ,9)",com.vaadin.ui;version="[8.0,9)",com.vaadin.v7.data;version="[8.0
 ,9)",com.vaadin.v7.data.util;version="[8.0,9)",com.vaadin.v7.data.uti
 l.converter;version="[8.0,9)",com.vaadin.v7.data.util.filter;version=
 "[8.0,9)",com.vaadin.v7.ui;version="[8.0,9)",javax.naming,javax.persi
 stence;version="[2.0,3)",javax.persistence.criteria;version="[2.0,3)"
 ,javax.persistence.metamodel;version="[2.0,3)",javax.transaction,org.
 hibernate.proxy
Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.7))"
Bundle-Developers: petter;email="petter at vaadin.com";name="Petter Ho
 lmström";organization="Vaadin Ltd";timezone="+2",hesara;email="hesar
 a at vaadin.com";name="Henri Sara";organization="Vaadin Ltd";timezone
 ="+2"
Tool: Bnd-4.2.0.201903051501
Implementation-Vendor: Vaadin Ltd
Export-Package: com.vaadin.addon.jpacontainer;version="4.0.1.SNAPSHOT"
 ;uses:="com.vaadin.v7.data,com.vaadin.v7.data.util.filter,javax.persi
 stence,javax.persistence.criteria",com.vaadin.addon.jpacontainer.filt
 er;version="4.0.1.SNAPSHOT";uses:="com.vaadin.v7.data,com.vaadin.v7.d
 ata.util.filter",com.vaadin.addon.jpacontainer.util;uses:="com.vaadin
 .addon.jpacontainer,javax.persistence.criteria";version="4.0.1.SNAPSH
 OT"
Bundle-Name: Vaadin JPAContainer Add-on
Bundle-Version: 4.0.1.SNAPSHOT
Bundle-SCM: url="https://github.com/vaadin/jpacontainer",connection="s
 cm:git:git@github.com:vaadin/jpacontainer.git",developer-connection="
 scm:git:git@github.com:vaadin/jpacontainer.git",tag=HEAD
Private-Package: com.vaadin.addon.jpacontainer.fieldfactory,com.vaadin
 .addon.jpacontainer.filter.util,com.vaadin.addon.jpacontainer.metadat
 a,com.vaadin.addon.jpacontainer.provider,com.vaadin.addon.jpacontaine
 r.provider.jndijta
Build-Jdk-Spec: 1.8
Created-By: 1.8.0_222 (Oracle Corporation)

If you ever touch jpacontainer, please add bnd.bnd. 

Best Regards,

Pekka